### PR TITLE
[#5] Abstract State Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ test.yaml
 config.yaml
 config.yml
 dist/
+
+tmp/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To use `dmon` download the newest release from the `Release`-tab of this GitHub 
 Then create a config file (structure is documented [below](#config)) and run `dmon` like this:
 
 ```bash
-dmon -c path/to/config.yml
+dmon -config path/to/config.yml
 ```
 
 ### Why was it developed?

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,10 @@ require (
 	google.golang.org/api v0.92.0
 )
 
-require github.com/gorilla/websocket v1.4.2 // indirect
+require (
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/jellydator/ttlcache/v3 v3.0.0 // indirect
+)
 
 require (
 	cloud.google.com/go/compute v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jellydator/ttlcache/v3 v3.0.0 h1:zmFhqrB/4sKiEiJHhtseJsNRE32IMVmJSs4++4gaQO4=
+github.com/jellydator/ttlcache/v3 v3.0.0/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/interfaces/api.go
+++ b/interfaces/api.go
@@ -4,5 +4,5 @@ import "github.com/yannickalex07/dmon/models"
 
 type API interface {
 	Jobs(project string, location string) ([]models.Job, error)
-	Messages(project string, location string, jobId string) ([]models.Message, error)
+	ErrorLogs(project string, location string, jobId string) ([]models.LogEntry, error)
 }

--- a/interfaces/handler.go
+++ b/interfaces/handler.go
@@ -5,6 +5,6 @@ import (
 )
 
 type Handler interface {
-	HandleError(cfg models.Config, job models.Job, messages []models.Message)
+	HandleError(cfg models.Config, job models.Job, entries []models.LogEntry)
 	HandleTimeout(cfg models.Config, job models.Job)
 }

--- a/interfaces/storage.go
+++ b/interfaces/storage.go
@@ -1,0 +1,11 @@
+package interfaces
+
+import "time"
+
+type Storage interface {
+	GetLatestRunTime() time.Time
+	SetLatestRunTime(newRunTime time.Time)
+
+	WasTimeoutHandled(id string) bool
+	TimeoutHandled(id string)
+}

--- a/interfaces/storage.go
+++ b/interfaces/storage.go
@@ -6,6 +6,6 @@ type Storage interface {
 	GetLatestRunTime() time.Time
 	SetLatestRunTime(newRunTime time.Time)
 
-	WasTimeoutHandled(id string) bool
+	TimeoutAlreadyHandled(id string) bool
 	TimeoutHandled(id string)
 }

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 	handlers = append(handlers, slackHandler)
 
 	// setup state storage
-	stateStore := storage.NewMemoryStore(cfg.ExpireTimeoutDuration() * time.Minute)
+	stateStore := storage.NewMemoryStore(cfg.ExpireTimeoutDuration())
 
 	// setup and start monitor
 	monitorFunc := func() {

--- a/main.go
+++ b/main.go
@@ -3,13 +3,16 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
+	"github.com/go-co-op/gocron"
 	log "github.com/sirupsen/logrus"
 	"github.com/yannickalex07/dmon/api"
 	"github.com/yannickalex07/dmon/config"
 	"github.com/yannickalex07/dmon/interfaces"
 	"github.com/yannickalex07/dmon/monitor"
 	"github.com/yannickalex07/dmon/slack"
+	"github.com/yannickalex07/dmon/storage"
 )
 
 func main() {
@@ -47,6 +50,15 @@ func main() {
 	}
 	handlers = append(handlers, slackHandler)
 
-	// start monitor
-	monitor.Start(*cfg, api.API{}, handlers)
+	// setup state storage
+	stateStore := storage.NewMemoryStore(cfg.ExpireTimeoutDuration() * time.Minute)
+
+	// setup and start monitor
+	monitorFunc := func() {
+		monitor.Monitor(*cfg, api.API{}, handlers, stateStore)
+	}
+
+	scheduler := gocron.NewScheduler(time.UTC)
+	scheduler.Every(cfg.RequestInterval).Minute().Do(monitorFunc)
+	scheduler.StartBlocking()
 }

--- a/models/entry.go
+++ b/models/entry.go
@@ -2,7 +2,7 @@ package models
 
 import "time"
 
-type Message struct {
+type LogEntry struct {
 	Text string
 	Time time.Time
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -74,7 +74,7 @@ func Monitor(cfg models.Config, api interfaces.API, handlers []interfaces.Handle
 				log.Infof("Job %s crossed max allowed timeout duration with a total runtime of %s", job.Id, totalRunTime)
 
 				// check if notification for job was already send
-				wasNotified := stateStore.WasTimeoutHandled(job.Id)
+				wasNotified := stateStore.TimeoutAlreadyHandled(job.Id)
 				if !wasNotified {
 
 					log.Infof("Timeout for job %s was not yet handled - handeling it now", job.Id)

--- a/slack/blocks.go
+++ b/slack/blocks.go
@@ -8,7 +8,7 @@ import (
 	"github.com/yannickalex07/dmon/models"
 )
 
-func createErrorBlocks(cfg models.Config, job models.Job, messages []models.Message) []slack.Block {
+func createErrorBlocks(cfg models.Config, job models.Job, entries []models.LogEntry) []slack.Block {
 	blocks := make([]slack.Block, 0)
 
 	// Title
@@ -39,7 +39,7 @@ func createErrorBlocks(cfg models.Config, job models.Job, messages []models.Mess
 		blocks = append(blocks, errorTitleHeaderBlock)
 
 		// Error Text
-		msgParts := strings.Split(messages[0].Text, "\n")
+		msgParts := strings.Split(entries[0].Text, "\n")
 		msg := msgParts[len(msgParts)-2] // last line is a blank line - before that comes the last error message
 		errorText := fmt.Sprintf("The last error message was: ```%s```", msg)
 

--- a/slack/handler.go
+++ b/slack/handler.go
@@ -12,8 +12,8 @@ type SlackHandler struct {
 	Channel string
 }
 
-func (s SlackHandler) HandleError(cfg models.Config, job models.Job, messages []models.Message) {
-	blocks := createErrorBlocks(cfg, job, messages)
+func (s SlackHandler) HandleError(cfg models.Config, job models.Job, entries []models.LogEntry) {
+	blocks := createErrorBlocks(cfg, job, entries)
 	s.send(blocks)
 }
 

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -32,7 +32,7 @@ func (s *MemoryStorage) SetLatestRunTime(newRunTime time.Time) {
 	s.lastRunTime = newRunTime
 }
 
-func (s MemoryStorage) WasTimeoutHandled(id string) bool {
+func (s MemoryStorage) TimeoutAlreadyHandled(id string) bool {
 	item := s.cache.Get(id)
 	return item != nil
 }

--- a/storage/memory_storage.go
+++ b/storage/memory_storage.go
@@ -1,0 +1,42 @@
+package storage
+
+import (
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+)
+
+type MemoryStorage struct {
+	cache       *ttlcache.Cache[string, string]
+	lastRunTime time.Time
+}
+
+func NewMemoryStore(ttl time.Duration) *MemoryStorage {
+	cache := ttlcache.New(
+		ttlcache.WithTTL[string, string](ttl),
+	)
+
+	go cache.Start()
+
+	return &MemoryStorage{
+		cache:       cache,
+		lastRunTime: time.Now().UTC(),
+	}
+}
+
+func (s MemoryStorage) GetLatestRunTime() time.Time {
+	return s.lastRunTime
+}
+
+func (s *MemoryStorage) SetLatestRunTime(newRunTime time.Time) {
+	s.lastRunTime = newRunTime
+}
+
+func (s MemoryStorage) WasTimeoutHandled(id string) bool {
+	item := s.cache.Get(id)
+	return item != nil
+}
+
+func (s *MemoryStorage) TimeoutHandled(id string) {
+	s.cache.Set(id, time.Now().UTC().String(), ttlcache.DefaultTTL)
+}


### PR DESCRIPTION
## Overview

This PR adds an abstract storage interface that can be used to store the necessary state.
The motivation behind this is to make it possible to store the state outside of memory.

The PR also adds a `MemoryStorage` that uses a `TTLCache` (#7) to store the last run time as well as the jobs ids that timed out.

## Checklist

- [x] - Added Tests
- [x] - Added Documentation

## Linked Issue

* #7 
* #5 